### PR TITLE
feat: add `root_path` config option

### DIFF
--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -4,7 +4,9 @@ const config = {
   config: {
     extends: "markdownlint/style/prettier",
     default: true,
-    "relative-links": true,
+    "relative-links": {
+      root_path: ".",
+    },
     "no-inline-html": false,
   },
   globs: ["**/*.md"],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks a lot for your interest in contributing to **markdownlint-rule-relative-l
 
 ## Code of Conduct
 
-**markdownlint-rule-relative-links** adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](./CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+**markdownlint-rule-relative-links** adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it. Please read [the full text](/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
 ## Open Development
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ awesome.md:3 relative-links Relative links should be valid ["./invalid.txt" shou
 - Support images (e.g: `![Image](./image.png)`).
 - Support links fragments similar to the [built-in `markdownlint` rule - MD051](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md) (e.g: `[Link](./awesome.md#heading)`).
 - Ignore external links and absolute paths as it only checks relative links (e.g: `https://example.com/` or `/absolute/path.png`).
-- If necessary, absolute paths can be validated too, with `root_path` configuration option.
+- If necessary, absolute paths can be validated too, with [`root_path` configuration option](#absolute-paths).
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ awesome.md:3 relative-links Relative links should be valid ["./invalid.txt" shou
 - Support images (e.g: `![Image](./image.png)`).
 - Support links fragments similar to the [built-in `markdownlint` rule - MD051](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md) (e.g: `[Link](./awesome.md#heading)`).
 - Ignore external links and absolute paths as it only checks relative links (e.g: `https://example.com/` or `/absolute/path.png`).
+- If necessary, absolute paths can be validated too, with `root_path` configuration option.
 
 ### Limitations
 
 - Only images and links defined using markdown syntax are validated, html syntax is ignored (e.g: `<a href="./link.txt" />` or `<img src="./image.png" />`).
 
-Contributions are welcome to improve the rule, and to alleviate these limitations. See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
+Contributions are welcome to improve the rule, and to alleviate these limitations. See [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
 
 ### Related links
 
@@ -108,6 +109,25 @@ export default config
 }
 ```
 
+### Absolute paths
+
+GitHub (and, likely, other similar platforms) resolves absolute paths in Markdown links relative to the repository root.
+
+To validate such links, add `root_path` option to the configuration:
+
+```js
+  config: {
+    default: true,
+    "relative-links": {
+      root_path: ".",
+    },
+  },
+```
+
+After this change, all absolute paths will be converted to relative paths, and will be resolved relative to the specified directory.
+
+For example, if you run markdownlint from a subdirectory (if `package.json` is located in a subdirectory), you should set `root_path` to `".."`.
+
 ## Usage
 
 ```sh
@@ -118,8 +138,8 @@ node --run lint:markdown
 
 Anyone can help to improve the project, submit a Feature Request, a bug report or even correct a simple spelling mistake.
 
-The steps to contribute can be found in the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
+The steps to contribute can be found in the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
 
 ## 📄 License
 
-[MIT](./LICENSE)
+[MIT](/LICENSE)

--- a/src/index.js
+++ b/src/index.js
@@ -51,17 +51,25 @@ const relativeLinksRule = {
           }
         }
 
-        if (hrefSrc == null) {
+        if (hrefSrc == null || hrefSrc.startsWith("#")) {
           continue
         }
 
-        const url = new URL(hrefSrc, pathToFileURL(params.name))
-        const isRelative =
-          url.protocol === "file:" &&
-          !hrefSrc.startsWith("/") &&
-          !hrefSrc.startsWith("#")
+        let url
 
-        if (!isRelative) {
+        if (hrefSrc.startsWith("/")) {
+          const rootPath = params.config["root_path"]
+
+          if (!rootPath) {
+            continue
+          }
+
+          url = new URL(`.${hrefSrc}`, pathToFileURL(`${rootPath}/`))
+        } else {
+          url = new URL(hrefSrc, pathToFileURL(params.name))
+        }
+
+        if (url.protocol !== "file:") {
           continue
         }
 

--- a/test/fixtures/config-dependent/absolute-paths.md
+++ b/test/fixtures/config-dependent/absolute-paths.md
@@ -1,0 +1,3 @@
+# Valid
+
+![Absolute Path](/test/fixtures/image.png)


### PR DESCRIPTION
# What changes this PR introduce?

New `root_path` config option. When it is set, all absolute paths are converted to relative, and then resolved relative to the `root_path`.

Also, I've changed links in markdown files in this repository to absolute ones - as an end-to-end test and demo.

## List any relevant issue numbers

https://github.com/theoludwig/markdownlint-rule-relative-links/issues/12

## Is there anything you'd like reviewers to focus on?
