### PR TITLE
Dumhoefer/add/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ awesome.md:3 relative-links Relative links should be valid ["./invalid.txt" shou
 - Support links fragments similar to the [built-in `markdownlint` rule - MD051](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md) (e.g: `[Link](./awesome.md#heading)`).
 - Ignore external links and absolute paths as it only checks relative links (e.g: `https://example.com/` or `/absolute/path.png`).
 - If necessary, absolute paths can be validated too, with [`root_path` configuration option](#absolute-paths).
+- Extra replacements can be defined with `replacement-map` as Key-Value pairs. This can be used, to replace special characters.  
+- Headings defined multiple times in one file, will get enumerated as `<heading><divider><count>`.  
+  The `<divider>` is `-` by default and can be customized with `fragment-count-divider`.  
 
 ### Limitations
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import mime from "mime"
 import { filterTokens } from "./markdownlint-rule-helpers/helpers.js"
 import {
   convertHeadingToHTMLFragment,
+  replaceMap,
   getMarkdownHeadings,
   getMarkdownIdOrAnchorNameFragments,
   isValidIntegerString,
@@ -143,13 +144,21 @@ const relativeLinksRule = {
 
         /** @type {Map<string, number>} */
         const fragments = new Map()
-
+        
+        let fragmentCountDivider = params.config["fragment-count-divider"]
+        if (! fragmentCountDivider){
+          fragmentCountDivider = '-'
+        }
+        let replacementMap = {}
+        if (params.config['replacement-map']){
+          replacementMap = params.config['replacement-map']
+        }
         const fragmentsHTML = headings.map((heading) => {
-          const fragment = convertHeadingToHTMLFragment(heading)
+          const fragment = replaceMap(convertHeadingToHTMLFragment(heading),replacementMap)
           const count = fragments.get(fragment) ?? 0
           fragments.set(fragment, count + 1)
           if (count !== 0) {
-            return `${fragment}-${count}`
+            return `${fragment}${fragmentCountDivider}${count}`
           }
           return fragment
         })

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,20 @@ export const convertHeadingToHTMLFragment = (inlineText) => {
   )
 }
 
+/**
+ * @param {string} text Text on which to replace.
+ * @param {Object<string|RegExp,string>} replacementMap Map of strings to replace.
+ * @returns {string} Text with all the keys replaced with their respective value.
+**/
+export const replaceMap = (text, replacementMap) =>{
+  for (const key of Object.keys(replacementMap)) {
+    const replacement = replacementMap[key]
+    if (!replacement) {continue}
+    text = text.replaceAll(key,replacement)
+  }
+  return text
+}
+
 const headingTags = new Set(["h1", "h2", "h3", "h4", "h5", "h6"])
 const ignoredTokens = new Set(["heading_open", "heading_close"])
 


### PR DESCRIPTION
<!-- Please first discuss the change you wish to make via issue before making a change. It might avoid a waste of your time. -->

# What changes this PR introduce?
## Two new configuration options:
### 1. replacement-map (in src/utils.js + src/index.js)

Adds a new replaceMap utility function that applies key-value string replacements to a heading fragment.
Allows users to define a replacement-map config option as key-value pairs to replace special characters in heading fragments before validation.
### 2. fragment-count-divider (in src/index.js)

When a heading appears multiple times in a file, markdownlint appends a count to deduplicate fragments (e.g., #heading-2).
Previously the divider was hardcoded to -. Now it's configurable via fragment-count-divider, defaulting to - if not set.
## Documentation of the Changes:
README.md — documents both new config options.

## List any relevant issue numbers 
Issues: #18 #17 