### PR TITLE
feat: add config-option for fragment-index-divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ awesome.md:3 relative-links Relative links should be valid ["./invalid.txt" shou
 - Ignore external links and absolute paths as it only checks relative links (e.g: `https://example.com/` or `/absolute/path.png`).
 - If necessary, absolute paths can be validated too, with [`root_path` configuration option](#absolute-paths).
 - Headings defined multiple times in one file, will get enumerated as `<heading><divider><count>`.
-  The `<divider>` is `-` by default and can be customized with `fragment-count-divider`.
+  The divier can be customized with [`fragment-count-divider`](#divider-for-fragment-index).
 
 ### Limitations
 
@@ -129,6 +129,16 @@ To validate such links, add `root_path` option to the configuration:
 After this change, all absolute paths will be converted to relative paths, and will be resolved relative to the specified directory.
 
 For example, if you run markdownlint from a subdirectory (if `package.json` is located in a subdirectory), you should set `root_path` to `".."`.
+
+### Divider for Fragment-Index
+
+Headers with the same name in the same file, are appended with their index when converting them to the fragment.
+Between the original fragment and the index a divider will be inserted.
+The final fragment is `<original-fragment><divider><index>`.
+
+This divider can be configured with `fragment-index-divider` to accomodate different markdown-engines.
+
+The default-value is `-`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ awesome.md:3 relative-links Relative links should be valid ["./invalid.txt" shou
 - Support links fragments similar to the [built-in `markdownlint` rule - MD051](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md) (e.g: `[Link](./awesome.md#heading)`).
 - Ignore external links and absolute paths as it only checks relative links (e.g: `https://example.com/` or `/absolute/path.png`).
 - If necessary, absolute paths can be validated too, with [`root_path` configuration option](#absolute-paths).
+- Extra replacements can be defined with `replacement-map` as Key-Value pairs. This can be used, to replace special characters.  
+- Headings defined multiple times in one file, will get enumerated as `<heading><divider><count>`.  
+  The `<divider>` is `-` by default and can be customized with `fragment-count-divider`.  
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ awesome.md:3 relative-links Relative links should be valid ["./invalid.txt" shou
 - Support links fragments similar to the [built-in `markdownlint` rule - MD051](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md) (e.g: `[Link](./awesome.md#heading)`).
 - Ignore external links and absolute paths as it only checks relative links (e.g: `https://example.com/` or `/absolute/path.png`).
 - If necessary, absolute paths can be validated too, with [`root_path` configuration option](#absolute-paths).
-- Extra replacements can be defined with `replacement-map` as Key-Value pairs. This can be used, to replace special characters.  
-- Headings defined multiple times in one file, will get enumerated as `<heading><divider><count>`.  
-  The `<divider>` is `-` by default and can be customized with `fragment-count-divider`.  
+- Headings defined multiple times in one file, will get enumerated as `<heading><divider><count>`.
+  The `<divider>` is `-` by default and can be customized with `fragment-count-divider`.
 
 ### Limitations
 

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ const relativeLinksRule = {
         /** @type {Map<string, number>} */
         const fragments = new Map()
 
-        const fragmentCountDivider = params.config["fragment-count-divider"] ?? "-"
+        const fragmentCountDivider = params.config["fragment-id-divider"] ?? "-"
 
         const fragmentsHTML = headings.map((heading) => {
           const fragment = convertHeadingToHTMLFragment(heading)

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ const relativeLinksRule = {
         /** @type {Map<string, number>} */
         const fragments = new Map()
 
-        const fragmentCountDivider = params.config["fragment-id-divider"] ?? "-"
+        const fragmentCountDivider = params.config["fragment-index-divider"] ?? "-"
 
         const fragmentsHTML = headings.map((heading) => {
           const fragment = convertHeadingToHTMLFragment(heading)

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import mime from "mime"
 import { filterTokens } from "./markdownlint-rule-helpers/helpers.js"
 import {
   convertHeadingToHTMLFragment,
+  replaceMap,
   getMarkdownHeadings,
   getMarkdownIdOrAnchorNameFragments,
   isValidIntegerString,
@@ -143,13 +144,21 @@ const relativeLinksRule = {
 
         /** @type {Map<string, number>} */
         const fragments = new Map()
-
+        
+        let fragmentCountDivider = params.config["fragment-count-divider"]
+        if (! fragmentCountDivider){
+          fragmentCountDivider = '-'
+        }
+        let replacementMap = {}
+        if (params.config['replacement-map']){
+          replacementMap = params.config['replacement-map']
+        }
         const fragmentsHTML = headings.map((heading) => {
-          const fragment = convertHeadingToHTMLFragment(heading)
+          const fragment = replaceMap(convertHeadingToHTMLFragment(heading),replacementMap)
           const count = fragments.get(fragment) ?? 0
           fragments.set(fragment, count + 1)
           if (count !== 0) {
-            return `${fragment}-${count}`
+            return `${fragment}${fragmentCountDivider}${count}`
           }
           return fragment
         })

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import mime from "mime"
 import { filterTokens } from "./markdownlint-rule-helpers/helpers.js"
 import {
   convertHeadingToHTMLFragment,
-  replaceMap,
   getMarkdownHeadings,
   getMarkdownIdOrAnchorNameFragments,
   isValidIntegerString,
@@ -144,17 +143,11 @@ const relativeLinksRule = {
 
         /** @type {Map<string, number>} */
         const fragments = new Map()
-        
-        let fragmentCountDivider = params.config["fragment-count-divider"]
-        if (! fragmentCountDivider){
-          fragmentCountDivider = '-'
-        }
-        let replacementMap = {}
-        if (params.config['replacement-map']){
-          replacementMap = params.config['replacement-map']
-        }
+
+        const fragmentCountDivider = params.config["fragment-count-divider"] ?? "-"
+
         const fragmentsHTML = headings.map((heading) => {
-          const fragment = replaceMap(convertHeadingToHTMLFragment(heading),replacementMap)
+          const fragment = convertHeadingToHTMLFragment(heading)
           const count = fragments.get(fragment) ?? 0
           fragments.set(fragment, count + 1)
           if (count !== 0) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,20 @@ export const convertHeadingToHTMLFragment = (inlineText) => {
   )
 }
 
+/**
+ * @param {string} text Text on which to replace.
+ * @param {Object<string|RegExp,string>} replacementMap Map of strings to replace.
+ * @returns {string} Text with all the keys replaced with their respective value.
+**/
+export const replaceMap = (text, replacementMap) =>{
+  for (const key of Object.keys(replacementMap)) {
+    const replacement = replacementMap[key]
+    if (!replacement) {continue}
+    text = text.replaceAll(key,replacement)
+  }
+  return text
+}
+
 const headingTags = new Set(["h1", "h2", "h3", "h4", "h5", "h6"])
 const ignoredTokens = new Set(["heading_open", "heading_close"])
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,20 +29,6 @@ export const convertHeadingToHTMLFragment = (inlineText) => {
   )
 }
 
-/**
- * @param {string} text Text on which to replace.
- * @param {Object<string|RegExp,string>} replacementMap Map of strings to replace.
- * @returns {string} Text with all the keys replaced with their respective value.
-**/
-export const replaceMap = (text, replacementMap) =>{
-  for (const key of Object.keys(replacementMap)) {
-    const replacement = replacementMap[key]
-    if (!replacement) {continue}
-    text = text.replaceAll(key,replacement)
-  }
-  return text
-}
-
 const headingTags = new Set(["h1", "h2", "h3", "h4", "h5", "h6"])
 const ignoredTokens = new Set(["heading_open", "heading_close"])
 

--- a/test/fixtures/valid/existing-heading-fragment-divider/awesome.md
+++ b/test/fixtures/valid/existing-heading-fragment-divider/awesome.md
@@ -1,0 +1,13 @@
+# Awesome
+
+## Existing Heading
+
+### Repeated Heading
+
+Text
+
+### Repeated Heading
+
+Text
+
+### Repeated Heading

--- a/test/fixtures/valid/existing-heading-fragment-divider/existing-heading-fragment.md
+++ b/test/fixtures/valid/existing-heading-fragment-divider/existing-heading-fragment.md
@@ -1,0 +1,9 @@
+# Valid
+
+[Link fragment](./awesome.md#existing-heading)
+
+[Link fragment Repeated 0](./awesome.md#repeated-heading)
+
+[Link fragment Repeated 1](./awesome.md#repeated-heading_1)
+
+[Link fragment Repeated 2](./awesome.md#repeated-heading_2)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -240,6 +240,16 @@ test("ensure the rule validates correctly", async (t) => {
         },
       },
       {
+        name: "should be valid with multiple existing element id fragments",
+        fixturePath:
+          "test/fixtures/valid/existing-heading-fragment-divider/existing-heading-fragment.md",
+        config: {
+          "relative-links": {
+            "fragment-index-divider": "_",
+          },
+        },
+      },
+      {
         name: "should ignore external image links",
         fixturePath: "test/fixtures/valid/ignore-external-image.md",
       },


### PR DESCRIPTION
# What changes this PR introduce?
## New configuration options `fragment-count-divider` (in src/index.js)

When a heading appears multiple times in a file, markdownlint appends a count to deduplicate fragments (e.g., #heading-2).
Previously the divider was hardcoded to -. Now it's configurable via fragment-count-divider, defaulting to - if not set.
## Documentation of the Changes:
README.md — documents new config options.

## List any relevant issue numbers 
Issues: #18 